### PR TITLE
Change accordian value to be unique by using subtitle

### DIFF
--- a/src/components/work/WorkItem.tsx
+++ b/src/components/work/WorkItem.tsx
@@ -33,7 +33,7 @@ export default function WorkItem(props: Props) {
   }
 
   return (
-    <Accordion.Item value={props.title} key={props.title}>
+    <Accordion.Item value={props.title+"-"+props.subtitle} key={props.title}>
       <Accordion.Control>
         <Flex justify="space-between" fw="bold" mr={20}>
           <Title order={4} m={0}>

--- a/src/components/work/WorkItem.tsx
+++ b/src/components/work/WorkItem.tsx
@@ -33,7 +33,7 @@ export default function WorkItem(props: Props) {
   }
 
   return (
-    <Accordion.Item value={props.title+"-"+props.subtitle} key={props.title}>
+    <Accordion.Item value={props.title+"-"+props.subtitle}>
       <Accordion.Control>
         <Flex justify="space-between" fw="bold" mr={20}>
           <Title order={4} m={0}>


### PR DESCRIPTION
Currently if you select software developer on works page, both bus planner and QC career school will dropdown, this is due to using key/value of software developer which is not unique.

<img width="743" height="866" alt="Screenshot 2025-07-27 at 3 44 04 PM" src="https://github.com/user-attachments/assets/5b2ea952-6f26-497d-8fe7-24f353cbdb09" />
